### PR TITLE
bugfix(webclient): recognize as contest-url or problem-url even if URL contains hiphen or underscores

### DIFF
--- a/webclient/src/atcoder/urls.rs
+++ b/webclient/src/atcoder/urls.rs
@@ -1,9 +1,9 @@
 use crate::{problem_id, Platform, ProblemId, Url, UrlAnalyzer};
 use ::lazy_regex::{lazy_regex, Lazy, Regex};
 
-pub(super) static RE_CONTEST_URL_PATH: Lazy<Regex> = lazy_regex!(r"^/contests/([[:alnum:]]+)/?$");
+pub(super) static RE_CONTEST_URL_PATH: Lazy<Regex> = lazy_regex!(r"^/contests/([0-9A-Za-z_-]+)/?$");
 pub(super) static RE_PROBLEM_URL_PATH: Lazy<Regex> =
-    lazy_regex!(r"^/contests/([[:alnum:]]+)/tasks/(([[:alnum:]]+)_([[:alnum:]]+))/?$");
+    lazy_regex!(r"^/contests/([0-9A-Za-z_-]+)/tasks/(([0-9A-Za-z_-]+)_([[:alnum:]]+))/?$");
 
 pub(super) static RE_PROBLEMS_VIRTUAL_CONTEST_URL_FRAGMENT: Lazy<Regex> =
     lazy_regex!(r"^/contest/show/([a-zA-Z0-9-]+)");

--- a/webclient/tests/atcoder.rs
+++ b/webclient/tests/atcoder.rs
@@ -33,6 +33,9 @@ fn should_be_contest_home_url() {
     assert!(is_contest_url("https://atcoder.jp/contests/abc001#a?x")); // fragment is 'a?x'
     assert!(is_contest_url("https://atcoder.jp/contests/abc001?lang=en"));
     assert!(is_contest_url(
+        "https://atcoder.jp/contests/tenka1-2012-qualB"
+    ));
+    assert!(is_contest_url(
         "https://atcoder.jp/contests/abc001/?lang=ja"
     ));
     assert!(is_contest_url("https://atcoder.jp/contests/abc001/?hoge"));
@@ -138,6 +141,9 @@ fn should_be_problem_url() {
     ));
     assert!(is_problem_url(
         "https://atcoder.jp/contests/abc001/tasks/typical90_a/?hoge"
+    ));
+    assert!(is_problem_url(
+        "https://atcoder.jp/contests/tenka1-2012-qualB/tasks/tenka1_2012_7"
     ));
 }
 


### PR DESCRIPTION
fix #41
